### PR TITLE
upgrade maven, jruby, polyglot-ruby and mavengem-wagon versions

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -4,11 +4,11 @@
   <extension>
     <groupId>org.torquebox.mojo</groupId>
     <artifactId>mavengem-wagon</artifactId>
-    <version>0.2.1</version>
+    <version>1.0.3</version>
   </extension>
   <extension>
     <groupId>io.takari.polyglot</groupId>
     <artifactId>polyglot-ruby</artifactId>
-    <version>0.4.5</version>
+    <version>0.7.0</version>
   </extension>
 </extensions>

--- a/Mavenfile
+++ b/Mavenfile
@@ -21,6 +21,6 @@ build do
 end
 
 # just lock the versions
-properties 'jruby.version': '9.2.6.0'
+properties 'jruby.version': '9.4.5.0'
 
 # vim: syntax=Ruby

--- a/lib/maven.rb
+++ b/lib/maven.rb
@@ -1,6 +1,6 @@
 module Maven
 
-  VERSION = '3.3.9'.freeze
+  VERSION = '3.8.8'.freeze
 
   def self.exec( *args )
     if args.member?( '-Dverbose=true' ) || args.member?( '-Dverbose' ) || args.member?( '-X' )


### PR DESCRIPTION
I was able to run `mvn package` where I see:

```
[INFO] --- gem-maven-plugin:3.0.0:package (default-package) @ ruby-maven-libs ---
[INFO] include dependencies? false
[INFO]   Successfully built RubyGem
[INFO]   Name: ruby-maven-libs
[INFO]   Version: 3.8.8
[INFO]   File: ruby-maven-libs-3.8.8.gem
```

I couldn't find a way to make the plugin include the dependencies, passing `-DincludeDependencies=true` doesn't work.

fixes #2 