### PR TITLE
Update gemspec files setting to include all of maven-home and lib

### DIFF
--- a/ruby-maven-libs.gemspec
+++ b/ruby-maven-libs.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.description = "maven distribution as gem - no ruby executables !"
   s.email = ["m.kristian@web.de"]
   s.extra_rdoc_files = ["maven-home/README.txt", "maven-home/NOTICE", "maven-home/LICENSE", "README.md"]
-  s.files = ["README.md"] + Dir['maven-home/**']
+  s.files = ["README.md"] + Dir['maven-home/**/*'] + ["lib/maven.rb"]
   s.homepage = "https://github.com/jruby/ruby-maven-libs"
   s.licenses = ["Apache-2.0"]
   s.summary = "maven distribution as gem"


### PR DESCRIPTION
The gem should include the `lib/maven.rb` file and all of `maven-home`. However the current `Dir['maven-home/**']` pattern will only generate a 12kb gem without the necessary jars. This commit makes it explicit that all files from `maven-home` should be included.