### PR TITLE
Upgrade maven-core to 3.9.6

### DIFF
--- a/lib/maven.rb
+++ b/lib/maven.rb
@@ -1,6 +1,6 @@
 module Maven
 
-  VERSION = '3.8.10.dev'.freeze
+  VERSION = '3.9.6'.freeze
 
   def self.exec( *args )
     if args.member?( '-Dverbose=true' ) || args.member?( '-Dverbose' ) || args.member?( '-X' )


### PR DESCRIPTION
Beware that 'mvn package' will create jar with the current maven version being used, so it is necessary to use maven 3.9.6 while running the packaging task.

I set the gem version to 3.9.6 since this gem has been versioned according to the version of maven it packages.